### PR TITLE
Add support of default attributes and custom attributes #3

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,16 +18,18 @@ TextCounted::make('Meta title')
 
 ![Image of character counter](docs/screenshot.jpg)
 
-You can use the text and textarea fields with charactercounters on you Nova model. The max number of characters aren't enforced, but just encouraged with warning colors and the counter. (You could enforce the max number of characters with Nova's built in _rules_).
+You can use the text and textarea fields with charactercounters on you Nova model. The max number of characters aren't enforced, but just encouraged with warning colors and the counter. (You could enforce the max number of characters with Nova's built in _rules_ and with a _maxlength_ extra attribute).
 
 ```php
 TextCounted::make('Meta title')
     ->maxChars(60)
-    ->warningAt(50),
+    ->warningAt(50)
+    ->withMeta(['extraAttributes' => ['maxlength' => '65']]),
 
 TextareaCounted::make('Meta description')
     ->maxChars(160)
-    ->warningAt(150),
+    ->warningAt(150)
+    ->rows(3),
 ```
 
 The maxChars and warningAt are both optional. The color of the counter will change when the max or warningAt limit is reached.

--- a/resources/js/components/TextCounted/FormField.vue
+++ b/resources/js/components/TextCounted/FormField.vue
@@ -1,13 +1,15 @@
 <template>
-    <default-field :field="field">
+    <default-field :field="field" :errors="errors">
         <template slot="field">
             <div class="relative">
                 <input
                     type="text"
-                    v-model="value"
                     class="w-full form-control form-input form-input-bordered"
-                    :class="errorClasses"
-                    :placeholder="field.name"
+                    :id="field.attribute"
+                    :readonly="readonly"
+                    :required="required"
+                    v-model="value"
+                    v-bind="extraAttributes"
                 />
 
                 <charcounter :value="value" :max-chars="field.maxChars" :warning-threshold="field.warningAt"></charcounter>
@@ -31,6 +33,28 @@
 
         components: {
             Charcounter
+        },
+
+        computed: {
+            defaultAttributes() {
+                return {
+                    pattern: this.field.pattern,
+                    placeholder: this.field.placeholder || this.field.name,
+                    class: this.errorClasses,
+                }
+            },
+
+            extraAttributes() {
+                const attrs = this.field.extraAttributes
+
+                return {
+                    // Leave the default attributes even though we can now specify
+                    // whatever attributes we like because the old number field still
+                    // uses the old field attributes
+                    ...this.defaultAttributes,
+                    ...attrs,
+                }
+            },
         }
     }
 </script>

--- a/resources/js/components/TextareaCounted/FormField.vue
+++ b/resources/js/components/TextareaCounted/FormField.vue
@@ -1,12 +1,14 @@
 <template>
-    <default-field :field="field">
+    <default-field :field="field" :errors="errors" :full-width-content="true">
         <template slot="field">
             <div class="relative">
                 <textarea
+                    class="w-full form-control form-input form-input-bordered py-3 h-auto"
+                    :id="field.attribute"
+                    :readonly="readonly"
+                    :required="required"
                     v-model="value"
-                    class="w-full form-control form-input form-input-bordered min-h-textarea py-3"
-                    :class="errorClasses"
-                    :placeholder="field.name"
+                    v-bind="extraAttributes"
                 ></textarea>
 
                 <charcounter :value="value" :max-chars="field.maxChars" :warning-threshold="field.warningAt"></charcounter>
@@ -31,6 +33,25 @@
 
         components: {
             Charcounter
+        },
+
+        computed: {
+            defaultAttributes() {
+                return {
+                    rows: this.field.rows,
+                    class: this.errorClasses,
+                    placeholder: this.field.name,
+                }
+            },
+            
+            extraAttributes() {
+                const attrs = this.field.extraAttributes
+
+                return {
+                    ...this.defaultAttributes,
+                    ...attrs,
+                }
+            },
         }
     }
 </script>

--- a/src/TextareaCounted.php
+++ b/src/TextareaCounted.php
@@ -10,5 +10,36 @@ class TextareaCounted extends FieldCounted
      * @var string
      */
     public $component = 'textarea-counted';
+    
+    /**
+     * The number of rows used for the textarea.
+     *
+     * @var int
+     */
+    public $rows = 5;
 
+    /**
+     * Set the number of rows used for the textarea.
+     *
+     * @param  int $rows
+     * @return $this
+     */
+    public function rows($rows)
+    {
+        $this->rows = $rows;
+
+        return $this;
+    }
+
+    /**
+     * Prepare the element for JSON serialization.
+     *
+     * @return array
+     */
+    public function jsonSerialize()
+    {
+        return array_merge(parent::jsonSerialize(), [
+            'rows' => $this->rows,
+        ]);
+    }
 }


### PR DESCRIPTION
The goal of this PR is to allow extra attributes such as rows or maxlength to mimic the default Text and TextArea fields.
This will allow the syntax seen in issue #3.
```
TextCounted::make('Message')
    ->maxChars(160)
    ->warningAt(150)
    ->withMeta(['extraAttributes' => [
        'maxlength' => 160
    ]]),
```
The ID attribute has been added to make labels clickable.
It also adds the support of default nova attributes such as required or readonly.

For security reasons, I didn't compile the sources.